### PR TITLE
Add backup retention policy - keep only 7 latest backups

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -24,7 +24,7 @@ while true; do
         --region=$S3_BUCKET_LOCATION \
         --host=$S3_HOST_BASE \
         --host-bucket=$S3_HOST_BUCKET \
-        ls s3://${S3_BUCKET}${S3_PREFIX}/ | grep '\.sql\.gz$' | sort -r)
+        ls s3://${S3_BUCKET}${S3_PREFIX}/ | grep '\.sql\.gz$' | sort -r | awk '{print $4}')
     
     # Count and delete old backups
     COUNT=0

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -2,13 +2,10 @@ set -e
 
 while true; do
 
-    SQL_FILE=$(date '+%Y-%m-%d.%H').sql
+    SQL_FILE=$(date '+%Y-%m-%d.%H').sql.gz
 
-    # Dump database
-    mysqldump --no-tablespaces -h ${MYSQL_HOST:=127.0.0.1} -u ${MYSQL_USER:=gorse} -p${MYSQL_PASSWORD:=gorse_pass} --ssl-verify-server-cert=0 ${MYSQL_DATABASE:=gorse} users items feedback flask_dance_oauth > $SQL_FILE
-
-    # Compress SQL file
-    gzip $SQL_FILE
+    # Dump and compress database in one stream
+    mysqldump --no-tablespaces -h ${MYSQL_HOST:=127.0.0.1} -u ${MYSQL_USER:=gorse} -p${MYSQL_PASSWORD:=gorse_pass} --ssl-verify-server-cert=0 ${MYSQL_DATABASE:=gorse} users items feedback flask_dance_oauth | gzip > $SQL_FILE
 
     # Upload SQL file
     s3cmd --access_key=$S3_ACCESS_KEY \
@@ -16,10 +13,32 @@ while true; do
         --region=$S3_BUCKET_LOCATION \
         --host=$S3_HOST_BASE \
         --host-bucket=$S3_HOST_BUCKET \
-        put ${SQL_FILE}.gz s3://${S3_BUCKET}${S3_PREFIX}/${SQL_FILE}.gz
+        put $SQL_FILE s3://${S3_BUCKET}${S3_PREFIX}/$SQL_FILE
     
     # Remove local SQL file
-    rm *.sql.gz
+    rm $SQL_FILE
+
+    # Keep only the latest 7 backups on remote
+    BACKUP_FILES=$(s3cmd --access_key=$S3_ACCESS_KEY \
+        --secret_key=$S3_SECRET_KEY \
+        --region=$S3_BUCKET_LOCATION \
+        --host=$S3_HOST_BASE \
+        --host-bucket=$S3_HOST_BUCKET \
+        ls s3://${S3_BUCKET}${S3_PREFIX}/ | grep '\.sql\.gz$' | sort -r)
+    
+    # Count and delete old backups
+    COUNT=0
+    for FILE in $BACKUP_FILES; do
+        COUNT=$((COUNT + 1))
+        if [ $COUNT -gt 7 ]; then
+            s3cmd --access_key=$S3_ACCESS_KEY \
+                --secret_key=$S3_SECRET_KEY \
+                --region=$S3_BUCKET_LOCATION \
+                --host=$S3_HOST_BASE \
+                --host-bucket=$S3_HOST_BUCKET \
+                del $FILE
+        fi
+    done
 
     # Backup 1 day later.
     sleep 86400


### PR DESCRIPTION
## Summary

Add automatic cleanup of old backups on S3 to prevent unlimited storage growth.

## Changes

After uploading a new backup file:
1. List all  files from S3 bucket
2. Sort by date descending (newest first)
3. Keep first 7 files, delete older ones

## Benefits

- Prevents unlimited backup accumulation
- Reduces S3 storage costs
- Always keeps latest 7 backups available for recovery

## Test Plan

This is a cron job script. Can be tested manually by:
1. Setting up S3 credentials
2. Running the script once
3. Verifying only 7 backups remain on S3