### PR TITLE
Upgrade Python to 3.12 and Node to 24

### DIFF
--- a/docker/backup/Dockerfile
+++ b/docker/backup/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.12
 
 # Install MySQL client.
 RUN apt-get update && apt-get install -y mariadb-client

--- a/docker/cronjobs/Dockerfile
+++ b/docker/cronjobs/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.12
 
 RUN apt-get update && apt-get install -y python3-dev default-libmysqlclient-dev build-essential
 COPY requirements.txt requirements.txt

--- a/docker/jobs/Dockerfile
+++ b/docker/jobs/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.12
 
 RUN apt-get update && apt-get install -y python3-dev default-libmysqlclient-dev build-essential
 COPY requirements.txt requirements.txt

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -1,17 +1,16 @@
 ########################
 # STEP 1: Build frontend
 ########################
-FROM node:18
+FROM node:24
 RUN corepack enable && corepack prepare pnpm@latest --activate
 COPY frontend frontend
 WORKDIR /frontend
-ENV NODE_OPTIONS=--openssl-legacy-provider
 RUN pnpm install && pnpm build
 
 #################################
 # STEP 2: Setup python enviroment
 #################################
-FROM python:3.9
+FROM python:3.12
 
 # Install packages
 RUN apt-get update && apt-get install -y python3-dev default-libmysqlclient-dev build-essential


### PR DESCRIPTION
## Changes

- **Python**: 3.9 → 3.12 in all Dockerfiles (web, jobs, cronjobs, backup)
- **Node**: 18 → 24 in docker/web/Dockerfile
- Removed `NODE_OPTIONS=--openssl-legacy-provider` environment variable (no longer needed with Node 24 + Vite 6)

## Benefits

- Python 3.12: Performance improvements (~25% faster), better error messages, improved type hints
- Node 24: Latest LTS features, native OpenSSL 3.0 support without legacy provider workaround

## Files Changed

- `docker/web/Dockerfile`
- `docker/jobs/Dockerfile`
- `docker/cronjobs/Dockerfile`
- `docker/backup/Dockerfile`