### PR TITLE
Fix topic page not found

### DIFF
--- a/app.py
+++ b/app.py
@@ -137,16 +137,13 @@ def login():
 def privacy():
     return app.send_static_file("index.html")
 
-@app.route("/favorites")
-def favorites():
-    if not current_user.is_authenticated:
-        return redirect("/login")
-    session.permanent = True
-    return app.send_static_file("index.html")
 
-
-@app.route("/topic/<topic>")
-def topic(topic):
+@app.route("/<path:path>")
+def catch_all(path):
+    # Skip API routes and static files
+    if path.startswith("api/") or path.startswith("assets/") or "." in path:
+        # Let Flask handle as normal (will return 404 for invalid API routes)
+        return app.send_static_file(path) if "." in path else "Not Found", 404
     if not current_user.is_authenticated:
         return redirect("/login")
     session.permanent = True

--- a/app.py
+++ b/app.py
@@ -137,6 +137,21 @@ def login():
 def privacy():
     return app.send_static_file("index.html")
 
+@app.route("/favorites")
+def favorites():
+    if not current_user.is_authenticated:
+        return redirect("/login")
+    session.permanent = True
+    return app.send_static_file("index.html")
+
+
+@app.route("/topic/<topic>")
+def topic(topic):
+    if not current_user.is_authenticated:
+        return redirect("/login")
+    session.permanent = True
+    return app.send_static_file("index.html")
+
 
 def is_github_blob(url: str) -> bool:
     splits = url.split("/")

--- a/app.py
+++ b/app.py
@@ -138,18 +138,6 @@ def privacy():
     return app.send_static_file("index.html")
 
 
-@app.route("/<path:path>")
-def catch_all(path):
-    # Skip API routes and static files
-    if path.startswith("api/") or path.startswith("assets/") or "." in path:
-        # Let Flask handle as normal (will return 404 for invalid API routes)
-        return app.send_static_file(path) if "." in path else "Not Found", 404
-    if not current_user.is_authenticated:
-        return redirect("/login")
-    session.permanent = True
-    return app.send_static_file("index.html")
-
-
 def is_github_blob(url: str) -> bool:
     splits = url.split("/")
     return (
@@ -466,6 +454,14 @@ def extension_recommend_latency(user_id: str):
             )
         except gorse.GorseException as e:
             return Response(e.message, status=e.status_code)
+
+
+@app.route("/<path:path>")
+def catch_all(path):
+    if not current_user.is_authenticated:
+        return redirect("/login")
+    session.permanent = True
+    return app.send_static_file("index.html")
 
 
 if __name__ == "__main__":

--- a/app.py
+++ b/app.py
@@ -457,7 +457,7 @@ def extension_recommend_latency(user_id: str):
 
 
 @app.route("/<path:path>")
-def catch_all(path):
+def catch_all(_path):
     if not current_user.is_authenticated:
         return redirect("/login")
     session.permanent = True

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -10,6 +10,7 @@ import Home from "./views/Home.vue";
 import Favorites from "./views/Favorites.vue";
 import Login from "./views/Login.vue";
 import Privacy from "./views/Privacy.vue";
+import NotFound from "./views/NotFound.vue";
 
 const routes = [
   { path: '/', component: MainLayout, children: [
@@ -20,6 +21,7 @@ const routes = [
   { name: 'Login', path: '/login', component: Login },
   { name: 'Privacy', path: '/privacy', component: Privacy },
   { path: '/logout', redirect: '/login' },
+  { name: 'NotFound', path: '/:pathMatch(.*)*', component: NotFound },
 ];
 
 const router = createRouter({

--- a/frontend/src/views/NotFound.vue
+++ b/frontend/src/views/NotFound.vue
@@ -40,7 +40,7 @@
                 <router-link class="text-on-primary" to="/privacy">Privacy Policy</router-link>
               </li>
               <li>
-                <a class="text-on-primary" href="https://github.com/gorse-io/gitrec" target="_blank">Source @ GitHub</a>
+                <a class="text-on-primary" href="https://github.com/gorse-io/gitrec" target="_blank" rel="noopener noreferrer">Source @ GitHub</a>
               </li>
             </ul>
           </v-col>

--- a/frontend/src/views/NotFound.vue
+++ b/frontend/src/views/NotFound.vue
@@ -9,7 +9,7 @@
     <v-main>
       <v-container class="not-found-body">
         <p class="text-center">
-          <img src="/logo.png" width="256px" />
+          <img src="/logo.png" width="256px" alt="GitRec logo" />
         </p>
         <h1 class="text-center text-h2 mb-4">404</h1>
         <h5 class="text-center mb-6">

--- a/frontend/src/views/NotFound.vue
+++ b/frontend/src/views/NotFound.vue
@@ -1,0 +1,100 @@
+<template>
+  <div>
+    <v-app-bar color="primary" flat>
+      <v-container>
+        <span class="page-title">GitRec</span>
+      </v-container>
+    </v-app-bar>
+
+    <v-main>
+      <v-container class="not-found-body">
+        <p class="text-center">
+          <img src="/logo.png" width="256px" />
+        </p>
+        <h1 class="text-center text-h2 mb-4">404</h1>
+        <h5 class="text-center mb-6">
+          Page not found
+        </h5>
+        <p class="text-center">
+          <v-btn color="primary" size="large" to="/" prepend-icon="mdi-home" class="text-none">
+            Go Home
+          </v-btn>
+        </p>
+      </v-container>
+    </v-main>
+
+    <v-footer color="primary" class="page-footer">
+      <v-container>
+        <v-row>
+          <v-col cols="12" md="7">
+            <h5>About</h5>
+            <p class="text-on-primary">
+              GitRec is the missing recommender system for GitHub built to test the
+              usability of the Gorse open recommender system engine.
+            </p>
+          </v-col>
+          <v-col cols="12" md="5">
+            <h5 class="text-on-primary">Links</h5>
+            <ul class="footer-links">
+              <li>
+                <router-link class="text-on-primary" to="/privacy">Privacy Policy</router-link>
+              </li>
+              <li>
+                <a class="text-on-primary" href="https://github.com/gorse-io/gitrec" target="_blank">Source @ GitHub</a>
+              </li>
+            </ul>
+          </v-col>
+        </v-row>
+        <div class="copyright">© {{ currentYear }} zhenghaoz</div>
+      </v-container>
+    </v-footer>
+  </div>
+</template>
+
+<script>
+export default {
+  computed: {
+    currentYear() {
+      return new Date().getFullYear();
+    },
+  },
+};
+</script>
+
+<style>
+.page-title {
+  font-weight: 300;
+  font-size: 1.5rem;
+  color: #f5f5f5;
+}
+
+.not-found-body {
+  box-sizing: border-box;
+  min-width: 200px;
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 45px;
+}
+
+.page-footer {
+  margin-top: 24px;
+}
+
+.text-on-primary {
+  color: #f5f5f5;
+}
+
+.footer-links {
+  list-style: none;
+  padding-left: 0;
+}
+
+.footer-links li {
+  margin-bottom: 6px;
+}
+
+.copyright {
+  padding-top: 8px;
+  color: #f5f5f5;
+}
+</style>


### PR DESCRIPTION
修复 SPA 前端路由的 404 问题，并添加 404 页面。

功能：
- 使用 catch-all 路由 /<path:path> 统一处理 SPA 前端路由
- 已登录用户返回 index.html，未登录用户重定向到 /login
- 添加 404 NotFound 页面组件
- 前端添加 catch-all 路由 /:pathMatch(.*)* 显示 404 页面