### PR TITLE
feat: support .adoc format for AsciiDoc README files

### DIFF
--- a/app.py
+++ b/app.py
@@ -186,7 +186,7 @@ def get_repo(category: str = ""):
     content = repo.get_readme().decoded_content.decode("utf-8")
     if download_url.endswith(".rst"):
         html = publish_parts(content, writer_name="html")["html_body"]
-    elif download_url.endswith(".asciidoc") or download_url.endswith(".adoc"):
+    elif download_url.endswith((".asciidoc", ".adoc")):
         infile = io.StringIO(content)
         outfile = io.StringIO()
         asciidoc3api = AsciiDoc3API(asciidoc3.__path__[0] + '/asciidoc3.py')

--- a/app.py
+++ b/app.py
@@ -186,7 +186,7 @@ def get_repo(category: str = ""):
     content = repo.get_readme().decoded_content.decode("utf-8")
     if download_url.endswith(".rst"):
         html = publish_parts(content, writer_name="html")["html_body"]
-    elif download_url.endswith(".asciidoc"):
+    elif download_url.endswith(".asciidoc") or download_url.endswith(".adoc"):
         infile = io.StringIO(content)
         outfile = io.StringIO()
         asciidoc3api = AsciiDoc3API(asciidoc3.__path__[0] + '/asciidoc3.py')


### PR DESCRIPTION
支持  格式的 AsciiDoc README 文件识别。

修改：
- 在 README 格式判断中，同时识别  和  后缀
-  是 AsciiDoc 文件的标准扩展名，很多仓库使用这个格式