### PR TITLE
feat: add CDN cache for neighbors API endpoints

### DIFF
--- a/app.py
+++ b/app.py
@@ -342,7 +342,9 @@ def get_neighbors(repo_name: str):
         n = int(request.args.get("n", default="3"))
         offset = int(request.args.get("offset", default="0"))
         repo_names = gorse_client.get_neighbors(repo_name.lower(), n, offset)
-        return Response(json.dumps(repo_names), mimetype="application/json")
+        response = Response(json.dumps(repo_names), mimetype="application/json")
+        response.headers["Cache-Control"] = "public, max-age=3600"
+        return response
     except gorse.GorseException as e:
         return Response(e.message, status=e.status_code)
 
@@ -354,10 +356,12 @@ def get_neighbors_v2(repo_name: str):
         offset = int(request.args.get("offset", default="0"))
         scores = gorse_client.get_neighbors(repo_name.lower(), n, offset)
         if not current_user.is_authenticated:
-            return Response(
+            response = Response(
                 json.dumps({"is_authenticated": False, "scores": scores}),
                 mimetype="application/json",
             )
+            response.headers["Cache-Control"] = "public, max-age=3600"
+            return response
         else:
             # Upsert the repository if it doesn't exist in Gorse.
             if len(scores) == 0:
@@ -368,7 +372,7 @@ def get_neighbors_v2(repo_name: str):
                         upsert.delay(current_user.token["access_token"], repo_name.replace(":", "/"))
 
             github_client = Github(current_user.token["access_token"])
-            return Response(
+            response = Response(
                 json.dumps(
                     {
                         "is_authenticated": True,
@@ -380,6 +384,8 @@ def get_neighbors_v2(repo_name: str):
                 ),
                 mimetype="application/json",
             )
+            response.headers["Cache-Control"] = "public, max-age=3600"
+            return response
     except gorse.GorseException as e:
         return Response(e.message, status=e.status_code)
 

--- a/app.py
+++ b/app.py
@@ -360,7 +360,8 @@ def get_neighbors_v2(repo_name: str):
                 json.dumps({"is_authenticated": False, "scores": scores}),
                 mimetype="application/json",
             )
-            response.headers["Cache-Control"] = "public, max-age=3600"
+            response.headers["Cache-Control"] = "private, max-age=3600"
+            response.headers["Vary"] = "Cookie"
             return response
         else:
             # Upsert the repository if it doesn't exist in Gorse.
@@ -384,7 +385,8 @@ def get_neighbors_v2(repo_name: str):
                 ),
                 mimetype="application/json",
             )
-            response.headers["Cache-Control"] = "public, max-age=3600"
+            response.headers["Cache-Control"] = "private, max-age=3600"
+            response.headers["Vary"] = "Cookie"
             return response
     except gorse.GorseException as e:
         return Response(e.message, status=e.status_code)


### PR DESCRIPTION
Add Cache-Control header with public, max-age=3600 to get_neighbors and get_neighbors_v2 endpoints for CDN caching.