### PR TITLE
feat: add KV cache for GitHub README with scheduled cleanup

### DIFF
--- a/app.py
+++ b/app.py
@@ -178,6 +178,16 @@ def get_trending():
     """Fetch trending repositories from GitHub Trending API."""
     language = request.args.get("language", "all")
     since = request.args.get("since", "daily")
+    
+    # Check cache first (cache key: trending:{language}:{since})
+    cache_key = f"trending:{language}:{since}"
+    cached = get_cached(cache_key)
+    if cached:
+        response = make_response(cached)
+        response.headers["Cache-Control"] = "public, max-age=3600, s-maxage=3600"
+        return response
+    
+    # Fetch from GitHub Trending API
     url = (
         "https://raw.githubusercontent.com/isboyjc/github-trending-api/main/"
         f"data/{since}/{language}.json"
@@ -207,6 +217,9 @@ def get_trending():
         )
         return {"error": "Unexpected trending repositories response"}, 502
 
+    # Save to cache (1 hour expiry for trending data)
+    save_cache(cache_key, repos, expiry_hours=1)
+    
     response = make_response(repos)
     response.headers["Cache-Control"] = "public, max-age=3600, s-maxage=3600"
     return response

--- a/app.py
+++ b/app.py
@@ -34,6 +34,7 @@ from sqlalchemy.orm.exc import NoResultFound
 from werkzeug.middleware.proxy_fix import ProxyFix
 
 from jobs import pull, upsert
+from utils import KvCache, get_cached, save_cache
 
 # create flask app
 app = Flask(__name__, static_folder="./frontend/dist", static_url_path="/")
@@ -54,39 +55,6 @@ class OAuth(OAuthConsumerMixin, UserMixin, db.Model):
     login = db.Column(db.String(256), unique=True, nullable=False)
     pulled_at = db.Column(db.DateTime())
 
-
-class KvCache(db.Model):
-    __tablename__ = 'kv_cache'
-    
-    k = db.Column(db.String(256), primary_key=True)
-    v = db.Column(db.Text, nullable=False)
-    expire = db.Column(db.DateTime, nullable=False)
-    
-    DEFAULT_EXPIRY_HOURS = 24
-    
-    def is_expired(self):
-        return self.expire < datetime.utcnow()
-
-
-def get_cached(k: str) -> Optional[dict]:
-    """从缓存获取数据"""
-    cache = KvCache.query.get(k)
-    if cache and not cache.is_expired():
-        return json.loads(cache.v)
-    return None
-
-
-def save_cache(k: str, v: dict, expiry_hours: int = KvCache.DEFAULT_EXPIRY_HOURS):
-    """保存数据到缓存"""
-    cache = KvCache.query.get(k)
-    expire_time = datetime.utcnow() + timedelta(hours=expiry_hours)
-    if cache:
-        cache.v = json.dumps(v)
-        cache.expire = expire_time
-    else:
-        cache = KvCache(k=k, v=json.dumps(v), expire=expire_time)
-        db.session.add(cache)
-    db.session.commit()
 
 
 # setup SQLAlchemy backend
@@ -406,8 +374,9 @@ def get_repo(category: str = ""):
         "readme": emoji.emojize(str(soup), use_aliases=True),
     }
     
-    # Save to cache
-    save_cache(repo_id, result)
+    # Save to cache (only for public repos to avoid leaking private content)
+    if not repo.private:
+        save_cache(repo_id, result)
     
     return result
 

--- a/app.py
+++ b/app.py
@@ -5,7 +5,7 @@ import logging
 import requests
 import os
 import sys
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import List, Optional
 
 import asciidoc3
@@ -53,6 +53,40 @@ db = SQLAlchemy(app)
 class OAuth(OAuthConsumerMixin, UserMixin, db.Model):
     login = db.Column(db.String(256), unique=True, nullable=False)
     pulled_at = db.Column(db.DateTime())
+
+
+class KvCache(db.Model):
+    __tablename__ = 'kv_cache'
+    
+    k = db.Column(db.String(256), primary_key=True)
+    v = db.Column(db.Text, nullable=False)
+    expire = db.Column(db.DateTime, nullable=False)
+    
+    DEFAULT_EXPIRY_HOURS = 24
+    
+    def is_expired(self):
+        return self.expire < datetime.utcnow()
+
+
+def get_cached(k: str) -> Optional[dict]:
+    """从缓存获取数据"""
+    cache = KvCache.query.get(k)
+    if cache and not cache.is_expired():
+        return json.loads(cache.v)
+    return None
+
+
+def save_cache(k: str, v: dict, expiry_hours: int = KvCache.DEFAULT_EXPIRY_HOURS):
+    """保存数据到缓存"""
+    cache = KvCache.query.get(k)
+    expire_time = datetime.utcnow() + timedelta(hours=expiry_hours)
+    if cache:
+        cache.v = json.dumps(v)
+        cache.expire = expire_time
+    else:
+        cache = KvCache(k=k, v=json.dumps(v), expire=expire_time)
+        db.session.add(cache)
+    db.session.commit()
 
 
 # setup SQLAlchemy backend
@@ -272,18 +306,31 @@ def convert_github_blob(url: str) -> str:
 @app.route("/api/repo/<category>")
 @login_required
 def get_repo(category: str = ""):
+    # Get recommended repo
+    repo_id = None
     for _ in range(2):
         try:
             repo_id = gorse_client.get_recommend(current_user.login, category)[0]
-            full_name = repo_id.replace(":", "/")
-            github_client = Github(current_user.token["access_token"])
-            repo = github_client.get_repo(full_name)
-            download_url = repo.get_readme().download_url.lower()
             break
         except UnknownObjectException:
             logging.warn("repo %s not found" % repo_id)
             gorse_client.delete_item(repo_id)
-    # convert readme to html
+    
+    if repo_id is None:
+        return Response("No repository found", status=404)
+    
+    # Check cache first
+    cached = get_cached(repo_id)
+    if cached:
+        return cached
+    
+    # Fetch from GitHub API
+    full_name = repo_id.replace(":", "/")
+    github_client = Github(current_user.token["access_token"])
+    repo = github_client.get_repo(full_name)
+    download_url = repo.get_readme().download_url.lower()
+    
+    # Convert readme to html
     content = repo.get_readme().decoded_content.decode("utf-8")
     if download_url.endswith(".rst"):
         html = publish_parts(content, writer_name="html")["html_body"]
@@ -319,7 +366,8 @@ def get_repo(category: str = ""):
                 )
             elif is_github_blob(src):
                 img.attrs["src"] = convert_github_blob(src)
-    return {
+    
+    result = {
         "item_id": repo_id,
         "full_name": repo.full_name,
         "html_url": repo.html_url,
@@ -331,6 +379,11 @@ def get_repo(category: str = ""):
         "language": repo.language,
         "readme": emoji.emojize(str(soup), use_aliases=True),
     }
+    
+    # Save to cache
+    save_cache(repo_id, result)
+    
+    return result
 
 
 @app.route("/api/favorites")

--- a/app.py
+++ b/app.py
@@ -34,7 +34,7 @@ from sqlalchemy.orm.exc import NoResultFound
 from werkzeug.middleware.proxy_fix import ProxyFix
 
 from jobs import pull, upsert
-from utils import KvCache, get_cached, save_cache
+from utils import Base, get_cached, save_cache
 
 # create flask app
 app = Flask(__name__, static_folder="./frontend/dist", static_url_path="/")
@@ -146,21 +146,21 @@ def get_trending():
     """Fetch trending repositories from GitHub Trending API."""
     language = request.args.get("language", "all")
     since = request.args.get("since", "daily")
-    
+
     # Check cache first (cache key: trending:{language}:{since})
-    cache_key = f"trending:{language}:{since}"
+    cache_key = f"api:trending:{language}:{since}"
     cached = get_cached(cache_key)
-    if cached:
+    if cached is not None:
         response = make_response(cached)
         response.headers["Cache-Control"] = "public, max-age=3600, s-maxage=3600"
         return response
-    
+
     # Fetch from GitHub Trending API
     url = (
         "https://raw.githubusercontent.com/isboyjc/github-trending-api/main/"
         f"data/{since}/{language}.json"
     )
-    
+
     try:
         resp = requests.get(url, timeout=10)
         resp.raise_for_status()
@@ -187,7 +187,7 @@ def get_trending():
 
     # Save to cache (1 hour expiry for trending data)
     save_cache(cache_key, repos, expiry_hours=1)
-    
+
     response = make_response(repos)
     response.headers["Cache-Control"] = "public, max-age=3600, s-maxage=3600"
     return response
@@ -236,13 +236,13 @@ def fetch_hackernews_repo(story_id: int) -> Optional[dict]:
 def get_hackernews():
     """Fetch GitHub repositories from Hacker News"""
     # Check cache first
-    cache_key = "hackernews:showstories"
+    cache_key = "api:hackernews:showstories"
     cached = get_cached(cache_key)
-    if cached:
+    if cached is not None:
         response = make_response(cached)
         response.headers["Cache-Control"] = "public, max-age=3600, s-maxage=3600"
         return response
-    
+
     try:
         # Get top stories from Hacker News
         topstories_url = "https://hacker-news.firebaseio.com/v0/showstories.json"
@@ -255,10 +255,10 @@ def get_hackernews():
             repos = list(executor.map(fetch_hackernews_repo, story_ids[:50]))
 
         result = [repo for repo in repos if repo is not None]
-        
+
         # Save to cache (1 hour expiry)
         save_cache(cache_key, result, expiry_hours=1)
-        
+
         response = make_response(result)
         response.headers["Cache-Control"] = "public, max-age=3600, s-maxage=3600"
         return response
@@ -312,20 +312,22 @@ def get_repo(category: str = ""):
     
     if repo_id is None:
         return Response("No repository found", status=404)
-    
+
     # Check cache first
-    cached = get_cached(repo_id)
-    if cached:
+    cache_key = f"repo:{repo_id}"
+    cached = get_cached(cache_key)
+    if cached is not None:
         return cached
-    
+
     # Fetch from GitHub API
     full_name = repo_id.replace(":", "/")
     github_client = Github(current_user.token["access_token"])
     repo = github_client.get_repo(full_name)
-    download_url = repo.get_readme().download_url.lower()
-    
+    readme = repo.get_readme()
+    download_url = readme.download_url.lower()
+
     # Convert readme to html
-    content = repo.get_readme().decoded_content.decode("utf-8")
+    content = readme.decoded_content.decode("utf-8")
     if download_url.endswith(".rst"):
         html = publish_parts(content, writer_name="html")["html_body"]
     elif download_url.endswith((".asciidoc", ".adoc")):
@@ -373,11 +375,11 @@ def get_repo(category: str = ""):
         "language": repo.language,
         "readme": emoji.emojize(str(soup), use_aliases=True),
     }
-    
+
     # Save to cache (only for public repos to avoid leaking private content)
     if not repo.private:
-        save_cache(repo_id, result)
-    
+        save_cache(cache_key, result)
+
     return result
 
 
@@ -616,5 +618,6 @@ if __name__ == "__main__":
     if "--setup" in sys.argv:
         with app.app_context():
             db.create_all()
+            Base.metadata.create_all(bind=db.engine)
             db.session.commit()
             print("Database tables created")

--- a/app.py
+++ b/app.py
@@ -267,6 +267,14 @@ def fetch_hackernews_repo(story_id: int) -> Optional[dict]:
 @app.route("/api/hackernews")
 def get_hackernews():
     """Fetch GitHub repositories from Hacker News"""
+    # Check cache first
+    cache_key = "hackernews:showstories"
+    cached = get_cached(cache_key)
+    if cached:
+        response = make_response(cached)
+        response.headers["Cache-Control"] = "public, max-age=3600, s-maxage=3600"
+        return response
+    
     try:
         # Get top stories from Hacker News
         topstories_url = "https://hacker-news.firebaseio.com/v0/showstories.json"
@@ -278,7 +286,12 @@ def get_hackernews():
         with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
             repos = list(executor.map(fetch_hackernews_repo, story_ids[:50]))
 
-        response = make_response([repo for repo in repos if repo is not None])
+        result = [repo for repo in repos if repo is not None]
+        
+        # Save to cache (1 hour expiry)
+        save_cache(cache_key, result, expiry_hours=1)
+        
+        response = make_response(result)
         response.headers["Cache-Control"] = "public, max-age=3600, s-maxage=3600"
         return response
     except Exception as e:

--- a/cronjobs.py
+++ b/cronjobs.py
@@ -12,7 +12,7 @@ from sqlalchemy import create_engine, or_
 from sqlalchemy.orm import sessionmaker
 
 from utils import *
-from app import KvCache
+from utils import KvCache
 
 # Setup logger
 logger = get_logger("cronjobs")
@@ -94,11 +94,17 @@ def cleanup_expired_cache():
     Clean up expired KV cache entries.
     """
     session = Session()
-    expired_count = session.query(KvCache).filter(
-        KvCache.expire < datetime.datetime.utcnow()
-    ).delete()
-    session.commit()
-    logger.info(f"Cleaned up {expired_count} expired cache entries")
+    try:
+        expired_count = session.query(KvCache).filter(
+            KvCache.expire < datetime.datetime.utcnow()
+        ).delete(synchronize_session=False)
+        session.commit()
+        logger.info(f"Cleaned up {expired_count} expired cache entries")
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
 
 
 def insert_trending_entry():

--- a/cronjobs.py
+++ b/cronjobs.py
@@ -12,6 +12,7 @@ from sqlalchemy import create_engine, or_
 from sqlalchemy.orm import sessionmaker
 
 from utils import *
+from app import KvCache
 
 # Setup logger
 logger = get_logger("cronjobs")
@@ -88,6 +89,18 @@ def insert_trending():
     )
 
 
+def cleanup_expired_cache():
+    """
+    Clean up expired KV cache entries.
+    """
+    session = Session()
+    expired_count = session.query(KvCache).filter(
+        KvCache.expire < datetime.datetime.utcnow()
+    ).delete()
+    session.commit()
+    logger.info(f"Cleaned up {expired_count} expired cache entries")
+
+
 def insert_trending_entry():
     try:
         insert_trending()
@@ -130,13 +143,16 @@ def insert_users_entry():
 @click.command()
 @click.option("--update-users", is_flag=True)
 @click.option("--insert-trending", is_flag=True)
-def main(update_users: bool, insert_trending: bool):
+@click.option("--cleanup-cache", is_flag=True)
+def main(update_users: bool, insert_trending: bool, cleanup_cache: bool):
     threads = []
-    run_all = update_users is False and insert_trending is False
+    run_all = update_users is False and insert_trending is False and cleanup_cache is False
     if run_all or insert_trending:
         threads.append(Thread(target=insert_trending_entry))
     if run_all or update_users:
         threads.append(Thread(target=insert_users_entry))
+    if run_all or cleanup_cache:
+        threads.append(Thread(target=cleanup_expired_cache))
     for thread in threads:
         thread.start()
     for thread in threads:

--- a/cronjobs.py
+++ b/cronjobs.py
@@ -12,7 +12,6 @@ from sqlalchemy import create_engine, or_
 from sqlalchemy.orm import sessionmaker
 
 from utils import *
-from utils import KvCache
 
 # Setup logger
 logger = get_logger("cronjobs")

--- a/utils.py
+++ b/utils.py
@@ -81,13 +81,13 @@ class User(Base):
 class KvCache(Base):
     """Key-value cache model for storing API responses."""
     __tablename__ = 'kv_cache'
-    
+
     k = Column(String(256), primary_key=True)
     v = Column(Text, nullable=False)
     expire = Column(DateTime, nullable=False)
-    
+
     DEFAULT_EXPIRY_HOURS = 24
-    
+
     def is_expired(self) -> bool:
         """Check if cache entry has expired."""
         return self.expire < datetime.datetime.utcnow()
@@ -97,12 +97,12 @@ def get_cached(k: str) -> Optional[Any]:
     """Get cached data by key. Returns None if not found or expired."""
     from sqlalchemy import create_engine
     from sqlalchemy.orm import sessionmaker
-    
+
     engine = create_engine(os.getenv("SQLALCHEMY_DATABASE_URI"))
     Session = sessionmaker()
     Session.configure(bind=engine)
     session = Session()
-    
+
     try:
         cache = session.query(KvCache).filter(KvCache.k == k).first()
         if cache and not cache.is_expired():
@@ -116,12 +116,12 @@ def save_cache(k: str, v: Any, expiry_hours: int = KvCache.DEFAULT_EXPIRY_HOURS)
     """Save data to cache with optional expiry time in hours."""
     from sqlalchemy import create_engine
     from sqlalchemy.orm import sessionmaker
-    
+
     engine = create_engine(os.getenv("SQLALCHEMY_DATABASE_URI"))
     Session = sessionmaker()
     Session.configure(bind=engine)
     session = Session()
-    
+
     try:
         cache = session.query(KvCache).filter(KvCache.k == k).first()
         expire_time = datetime.datetime.utcnow() + datetime.timedelta(hours=expiry_hours)
@@ -132,6 +132,9 @@ def save_cache(k: str, v: Any, expiry_hours: int = KvCache.DEFAULT_EXPIRY_HOURS)
             cache = KvCache(k=k, v=json.dumps(v), expire=expire_time)
             session.add(cache)
         session.commit()
+    except Exception:
+        session.rollback()
+        raise
     finally:
         session.close()
 

--- a/utils.py
+++ b/utils.py
@@ -1,9 +1,10 @@
 import datetime
+import json
 import logging
 import os
 import re
 import sys
-from typing import List, Optional, Tuple, Dict
+from typing import List, Optional, Tuple, Dict, Any
 
 import pytz
 import requests
@@ -11,7 +12,7 @@ from dateutil import parser
 from github import Github
 from github.GithubException import *
 from gorse import Gorse, GorseException
-from sqlalchemy import Column, String, Integer, DateTime, JSON
+from sqlalchemy import Column, String, Integer, DateTime, JSON, Text
 from sqlalchemy.orm import declarative_base
 from openai import OpenAI
 from pydantic import BaseModel
@@ -75,6 +76,64 @@ class User(Base):
     login = Column(String)
     pulled_at = Column(DateTime)
 
+
+
+class KvCache(Base):
+    """Key-value cache model for storing API responses."""
+    __tablename__ = 'kv_cache'
+    
+    k = Column(String(256), primary_key=True)
+    v = Column(Text, nullable=False)
+    expire = Column(DateTime, nullable=False)
+    
+    DEFAULT_EXPIRY_HOURS = 24
+    
+    def is_expired(self) -> bool:
+        """Check if cache entry has expired."""
+        return self.expire < datetime.datetime.utcnow()
+
+
+def get_cached(k: str) -> Optional[Any]:
+    """Get cached data by key. Returns None if not found or expired."""
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+    
+    engine = create_engine(os.getenv("SQLALCHEMY_DATABASE_URI"))
+    Session = sessionmaker()
+    Session.configure(bind=engine)
+    session = Session()
+    
+    try:
+        cache = session.query(KvCache).filter(KvCache.k == k).first()
+        if cache and not cache.is_expired():
+            return json.loads(cache.v)
+        return None
+    finally:
+        session.close()
+
+
+def save_cache(k: str, v: Any, expiry_hours: int = KvCache.DEFAULT_EXPIRY_HOURS) -> None:
+    """Save data to cache with optional expiry time in hours."""
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+    
+    engine = create_engine(os.getenv("SQLALCHEMY_DATABASE_URI"))
+    Session = sessionmaker()
+    Session.configure(bind=engine)
+    session = Session()
+    
+    try:
+        cache = session.query(KvCache).filter(KvCache.k == k).first()
+        expire_time = datetime.datetime.utcnow() + datetime.timedelta(hours=expiry_hours)
+        if cache:
+            cache.v = json.dumps(v)
+            cache.expire = expire_time
+        else:
+            cache = KvCache(k=k, v=json.dumps(v), expire=expire_time)
+            session.add(cache)
+        session.commit()
+    finally:
+        session.close()
 
 class GraphQLGitHub:
     """


### PR DESCRIPTION
## Summary

- Add KvCache model for caching repo data as JSON (k/v/expire fields)
- Add get_cached/save_cache helper functions with configurable expiry
- Modify get_repo API to check cache before fetching from GitHub API
- Add cleanup_expired_cache scheduled task in cronjobs.py

## Benefits

1. Reduce GitHub API requests for README content
2. Faster response time for cached repos
3. Scheduled cleanup prevents expired cache accumulation
4. Generic KV cache design can be reused for other caching needs

## Usage

Default cache expiry: 24 hours

Cleanup via cronjobs:


Or run all scheduled tasks (includes cleanup):
