### PR TITLE
feat: support anonymous users

### DIFF
--- a/app.py
+++ b/app.py
@@ -376,26 +376,36 @@ def get_repo(category: str = ""):
         # Filter out already read repos from session
         read_repos = session.get("read_repos", [])
         available_repos = [
-            repo for repo in trending_data 
-            if repo.get("full_name", "").replace("/", ":").lower() not in read_repos
+            repo
+            for repo in trending_data
+            if isinstance(repo.get("full_name"), str)
+            and repo.get("full_name", "").strip()
+            and "/" in repo.get("full_name", "").strip()
+            and repo.get("full_name", "").strip().replace("/", ":").lower() not in read_repos
         ]
         
-        # If all repos have been read, reset session and use all trending repos
+        # If all repos have been read, reset session and use all valid trending repos
         if not available_repos:
-            available_repos = trending_data
+            available_repos = [
+                repo
+                for repo in trending_data
+                if isinstance(repo.get("full_name"), str)
+                and repo.get("full_name", "").strip()
+                and "/" in repo.get("full_name", "").strip()
+            ]
             session["read_repos"] = []
+        
+        if not available_repos:
+            return Response("No valid trending repositories available", status=404)
         
         # Randomly select a trending repo
         random_repo = random.choice(available_repos)
-        full_name = random_repo.get("url", "")
-        if full_name.startswith("https://github.com/"):
-            full_name = full_name.removeprefix("https://github.com/").strip("/")
-        else:
-            full_name = ""
-        repo_id = full_name.replace("/", ":").lower()
+        full_name = random_repo.get("full_name", "").strip()
         
-        if not full_name:
+        if not full_name or "/" not in full_name:
             return Response("Invalid trending repository", status=500)
+        
+        repo_id = full_name.replace("/", ":").lower()
         
         # Check cache first
         cache_key = f"repo:{repo_id}"

--- a/app.py
+++ b/app.py
@@ -372,8 +372,20 @@ def get_repo(category: str = ""):
         if not trending_data:
             return Response("No trending repositories available", status=404)
         
+        # Filter out already read repos from session
+        read_repos = session.get("read_repos", [])
+        available_repos = [
+            repo for repo in trending_data 
+            if repo.get("full_name", "").replace("/", ":").lower() not in read_repos
+        ]
+        
+        # If all repos have been read, reset session and use all trending repos
+        if not available_repos:
+            available_repos = trending_data
+            session["read_repos"] = []
+        
         # Randomly select a trending repo
-        random_repo = random.choice(trending_data)
+        random_repo = random.choice(available_repos)
         full_name = random_repo.get("full_name", "")
         repo_id = full_name.replace("/", ":").lower()
         
@@ -486,17 +498,28 @@ def like_repo(repo_name: str):
 
 
 @app.route("/api/read/<repo_name>", methods=["POST"])
-@login_required
 def read_repo(repo_name: str):
     """
     Insert a "read" feedback.
+    For logged-in users: insert to Gorse.
+    For anonymous users: save to session.
     """
-    try:
-        return gorse_client.insert_feedback(
-            "read", current_user.login, repo_name.lower(), datetime.now().isoformat(), 1
-        )
-    except gorse.GorseException as e:
-        return Response(e.message, status=e.status_code)
+    repo_name = repo_name.lower()
+    
+    if current_user.is_authenticated:
+        try:
+            return gorse_client.insert_feedback(
+                "read", current_user.login, repo_name, datetime.now().isoformat(), 1
+            )
+        except gorse.GorseException as e:
+            return Response(e.message, status=e.status_code)
+    else:
+        # For anonymous users, save read repos in session
+        read_repos = session.get("read_repos", [])
+        if repo_name not in read_repos:
+            read_repos.append(repo_name)
+            session["read_repos"] = read_repos
+        return Response(json.dumps({"success": True}), mimetype="application/json")
 
 
 @app.route("/api/delete/<repo_name>", methods=["POST"])

--- a/app.py
+++ b/app.py
@@ -348,15 +348,16 @@ def get_repo(category: str = ""):
         github_client = Github(current_user.token["access_token"])
     else:
         # For anonymous users, get a random trending repo
+        language = category.lower() if category else "all"
         # First try to get from trending cache
-        trending_cache_key = "api:trending:all:daily"
+        trending_cache_key = f"api:trending:{language}:daily"
         trending_data = get_cached(trending_cache_key)
         
         if trending_data is None:
             # Fetch trending data if not cached
             url = (
                 "https://raw.githubusercontent.com/isboyjc/github-trending-api/main/"
-                "data/daily/all.json"
+                f"data/daily/{language}.json"
             )
             try:
                 resp = requests.get(url, timeout=10)
@@ -386,7 +387,11 @@ def get_repo(category: str = ""):
         
         # Randomly select a trending repo
         random_repo = random.choice(available_repos)
-        full_name = random_repo.get("full_name", "")
+        full_name = random_repo.get("url", "")
+        if full_name.startswith("https://github.com/"):
+            full_name = full_name.removeprefix("https://github.com/").strip("/")
+        else:
+            full_name = ""
         repo_id = full_name.replace("/", ":").lower()
         
         if not full_name:

--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ import concurrent.futures
 import io
 import json
 import logging
+import random
 import requests
 import os
 import sys
@@ -319,30 +320,76 @@ def convert_github_blob(url: str) -> str:
 
 @app.route("/api/repo")
 @app.route("/api/repo/<category>")
-@login_required
 def get_repo(category: str = ""):
-    # Get recommended repo
-    repo_id = None
-    for _ in range(2):
-        try:
-            repo_id = gorse_client.get_recommend(current_user.login, category)[0]
-            break
-        except UnknownObjectException:
-            logging.warn("repo %s not found" % repo_id)
-            gorse_client.delete_item(repo_id)
+    """Get a recommended repository. Uses Gorse for logged-in users, 
+    or random trending repo for anonymous users."""
     
-    if repo_id is None:
-        return Response("No repository found", status=404)
-
-    # Check cache first
-    cache_key = f"repo:{repo_id}"
-    cached = get_cached(cache_key)
-    if cached is not None:
-        return cached
-
+    if current_user.is_authenticated:
+        # Get recommended repo for logged-in users
+        repo_id = None
+        for _ in range(2):
+            try:
+                repo_id = gorse_client.get_recommend(current_user.login, category)[0]
+                break
+            except UnknownObjectException:
+                logging.warn("repo %s not found" % repo_id)
+                gorse_client.delete_item(repo_id)
+        
+        if repo_id is None:
+            return Response("No repository found", status=404)
+        
+        # Check cache first
+        cache_key = f"repo:{repo_id}"
+        cached = get_cached(cache_key)
+        if cached is not None:
+            return cached
+        
+        full_name = repo_id.replace(":", "/")
+        github_client = Github(current_user.token["access_token"])
+    else:
+        # For anonymous users, get a random trending repo
+        # First try to get from trending cache
+        trending_cache_key = "api:trending:all:daily"
+        trending_data = get_cached(trending_cache_key)
+        
+        if trending_data is None:
+            # Fetch trending data if not cached
+            url = (
+                "https://raw.githubusercontent.com/isboyjc/github-trending-api/main/"
+                "data/daily/all.json"
+            )
+            try:
+                resp = requests.get(url, timeout=10)
+                resp.raise_for_status()
+                payload = resp.json()
+                trending_data = payload.get("items", [])
+                if trending_data:
+                    save_cache(trending_cache_key, trending_data, expiry_hours=1)
+            except Exception as e:
+                app.logger.error(f"Error fetching trending for anonymous user: {e}")
+                return Response("Failed to fetch trending repositories", status=500)
+        
+        if not trending_data:
+            return Response("No trending repositories available", status=404)
+        
+        # Randomly select a trending repo
+        random_repo = random.choice(trending_data)
+        full_name = random_repo.get("full_name", "")
+        repo_id = full_name.replace("/", ":").lower()
+        
+        if not full_name:
+            return Response("Invalid trending repository", status=500)
+        
+        # Check cache first
+        cache_key = f"repo:{repo_id}"
+        cached = get_cached(cache_key)
+        if cached is not None:
+            return cached
+        
+        # Use global github client for anonymous users
+        github_client = global_github_client
+    
     # Fetch from GitHub API
-    full_name = repo_id.replace(":", "/")
-    github_client = Github(current_user.token["access_token"])
     repo = github_client.get_repo(full_name)
     readme = repo.get_readme()
     download_url = readme.download_url.lower()

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -5,7 +5,18 @@
         <v-list-item title="Explore" :active="isExploreRoute" @click="goTo('/')" />
         <v-list-item title="Trending" :active="isTrendingRoute" @click="goTo('/trending')" />
         <v-list-item v-if="isAuthenticated" title="Favorites" :active="$route.path === '/favorites'" @click="goTo('/favorites')" />
-        <v-list-item prepend-icon="mdi-github" href="https://github.com/gorse-io/gitrec" target="_blank" />
+        <v-list-item v-if="isAuthenticated">
+          <div class="d-flex align-center w-100">
+            <v-btn variant="text" icon="mdi-github" href="https://github.com/gorse-io/gitrec" target="_blank" />
+            <v-btn variant="text" icon="mdi-logout" @click="logout" />
+          </div>
+        </v-list-item>
+        <v-list-item v-if="!isAuthenticated">
+          <div class="d-flex align-center w-100">
+            <v-btn variant="text" icon="mdi-github" href="https://github.com/gorse-io/gitrec" target="_blank" />
+            <v-btn variant="text" icon="mdi-login" @click="goTo('/login')" />
+          </div>
+        </v-list-item>
       </v-list>
     </v-navigation-drawer>
 
@@ -216,7 +227,7 @@ export default {
       try {
         await axios.get("/api/logout");
         localStorage.removeItem("gitrec_auth_state");
-        this.$router.push("/login");
+        this.$router.push("/");
       } catch (error) {
         console.error("Logout failed:", error);
       }

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -4,7 +4,7 @@
       <v-list nav density="comfortable">
         <v-list-item title="Explore" :active="isExploreRoute" @click="goTo('/')" />
         <v-list-item title="Trending" :active="isTrendingRoute" @click="goTo('/trending')" />
-        <v-list-item title="Favorites" :active="$route.path === '/favorites'" @click="goTo('/favorites')" />
+        <v-list-item v-if="isAuthenticated" title="Favorites" :active="$route.path === '/favorites'" @click="goTo('/favorites')" />
         <v-list-item prepend-icon="mdi-github" href="https://github.com/gorse-io/gitrec" target="_blank" />
       </v-list>
     </v-navigation-drawer>
@@ -20,7 +20,7 @@
         <div class="d-none d-md-flex align-center ga-1">
           <v-btn variant="text" :to="'/'" :active="isExploreRoute" color="white">Explore</v-btn>
           <v-btn variant="text" :to="'/trending'" :active="isTrendingRoute" color="white">Trending</v-btn>
-          <v-btn variant="text" :to="'/favorites'" :active="$route.path === '/favorites'" color="white">Favorites</v-btn>
+          <v-btn v-if="isAuthenticated" variant="text" :to="'/favorites'" :active="$route.path === '/favorites'" color="white">Favorites</v-btn>
 
           <v-menu location="bottom end">
             <template #activator="{ props }">
@@ -48,7 +48,8 @@
           </v-menu>
 
           <v-btn variant="text" href="https://github.com/gorse-io/gitrec" target="_blank" color="white" icon="mdi-github" />
-          <v-btn variant="text" color="white" icon="mdi-logout" @click="logout" />
+          <v-btn v-if="isAuthenticated" variant="text" color="white" icon="mdi-logout" @click="logout" />
+          <v-btn v-if="!isAuthenticated" variant="text" color="white" icon="mdi-login" to="/login" />
         </div>
       </v-container>
 
@@ -63,7 +64,7 @@
             class="topic-tabs"
           >
             <v-tab
-              v-for="topic in topics"
+              v-for="topic in visibleTopics"
               :key="topic"
               :value="topicToPath(topic)"
               :to="topicToPath(topic)"
@@ -111,6 +112,7 @@ export default {
   data() {
     return {
       drawer: false,
+      isAuthenticated: false,
       topics: [
         "all",
         "ai",
@@ -159,8 +161,42 @@ export default {
     activeLanguage() {
       return this.$route.params.language || "all";
     },
+    // Filter topics: hide 'ai' for anonymous users
+    visibleTopics() {
+      if (this.isAuthenticated) {
+        return this.topics;
+      }
+      return this.topics.filter(topic => topic !== "ai");
+    },
+  },
+  async mounted() {
+    await this.checkAuth();
   },
   methods: {
+    async checkAuth() {
+      const cached = localStorage.getItem("gitrec_auth_state");
+      if (cached) {
+        const { is_authenticated, timestamp } = JSON.parse(cached);
+        if (Date.now() - timestamp < 5 * 60 * 1000) {
+          this.isAuthenticated = is_authenticated;
+          return;
+        }
+      }
+      
+      try {
+        const response = await axios.get("/api/me", { withCredentials: true });
+        this.isAuthenticated = response.data.is_authenticated;
+        if (this.isAuthenticated) {
+          localStorage.setItem("gitrec_auth_state", JSON.stringify({
+            is_authenticated: true,
+            login: response.data.login,
+            timestamp: Date.now()
+          }));
+        }
+      } catch (error) {
+        this.isAuthenticated = false;
+      }
+    },
     goTo(path) {
       this.drawer = false;
       if (this.$route.path !== path) {

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -187,10 +187,14 @@ export default {
     async checkAuth() {
       const cached = localStorage.getItem("gitrec_auth_state");
       if (cached) {
-        const { is_authenticated, timestamp } = JSON.parse(cached);
-        if (Date.now() - timestamp < 5 * 60 * 1000) {
-          this.isAuthenticated = is_authenticated;
-          return;
+        try {
+          const { is_authenticated, timestamp } = JSON.parse(cached);
+          if (Date.now() - timestamp < 5 * 60 * 1000) {
+            this.isAuthenticated = is_authenticated;
+            return;
+          }
+        } catch (error) {
+          localStorage.removeItem("gitrec_auth_state");
         }
       }
       
@@ -203,8 +207,11 @@ export default {
             login: response.data.login,
             timestamp: Date.now()
           }));
+        } else {
+          localStorage.removeItem("gitrec_auth_state");
         }
       } catch (error) {
+        localStorage.removeItem("gitrec_auth_state");
         this.isAuthenticated = false;
       }
     },
@@ -227,6 +234,7 @@ export default {
       try {
         await axios.get("/api/logout");
         localStorage.removeItem("gitrec_auth_state");
+        this.isAuthenticated = false;
         this.$router.push("/");
       } catch (error) {
         console.error("Logout failed:", error);

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -16,11 +16,11 @@ import NotFound from "./views/NotFound.vue";
 
 const routes = [
   { path: '/', component: MainLayout, children: [
-    { name: 'Explore', path: '', component: Home, meta: { requiresAuth: true } },
+    { name: 'Explore', path: '', component: Home },
     { name: 'Favorites', path: 'favorites', component: Favorites, meta: { requiresAuth: true } },
     { name: 'Trending', path: 'trending', component: Trending },
     { name: 'Trending Language', path: 'trending/:language', component: Trending },
-    { name: 'Explore Topic', path: 'topic/:topic', component: Home, meta: { requiresAuth: true } },
+    { name: 'Explore Topic', path: 'topic/:topic', component: Home },
   ]},
   { name: 'Login', path: '/login', component: Login },
   { name: 'Privacy', path: '/privacy', component: Privacy },
@@ -62,12 +62,14 @@ function clearCachedAuthState() {
 }
 
 // Global axios interceptor for 401 errors
+// Only redirect to login for Favorites route (requires auth)
 axios.interceptors.response.use(
   (response) => response,
   (error) => {
     if (error.response?.status === 401) {
       clearCachedAuthState();
-      if (window.location.pathname !== "/login") {
+      // Only redirect to login if on Favorites page
+      if (window.location.pathname === "/favorites") {
         router.push("/login");
       }
     }

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -1,21 +1,17 @@
 <template>
   <div>
     <!-- Login prompt for anonymous users -->
-    <v-banner 
+    <v-alert
       v-if="!isAuthenticated && !hideLoginPrompt"
-      color="info"
-      lines="one"
-      class="login-banner"
+      type="info"
+      variant="tonal"
+      class="login-alert"
+      @click="goToLogin"
     >
-      <v-banner-text>
-        <v-icon start>mdi-information</v-icon>
+      <div class="login-alert__text">
         Login with GitHub to get personalized recommendations based on your starred repositories
-      </v-banner-text>
-      <template #actions>
-        <v-btn color="primary" to="/login" variant="text">Login</v-btn>
-        <v-btn variant="text" @click="hideLoginPrompt = true">Dismiss</v-btn>
-      </template>
-    </v-banner>
+      </div>
+    </v-alert>
 
     <v-container>
       <div v-if="full_name" class="repo-header">
@@ -115,6 +111,9 @@ export default {
     this.recommend();
   },
   methods: {
+    goToLogin() {
+      this.$router.push("/login");
+    },
     async checkAuth() {
       const cached = localStorage.getItem("gitrec_auth_state");
       if (cached) {
@@ -200,6 +199,15 @@ export default {
 </script>
 
 <style>
+.login-alert {
+  cursor: pointer;
+}
+
+.login-alert__text {
+  white-space: normal;
+  line-height: 1.5;
+}
+
 .markdown-body {
   box-sizing: border-box;
   min-width: 200px;

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -57,6 +57,7 @@ export default {
   data() {
     return {
       like_pressed: false,
+      isAuthenticated: false,
       item_id: null,
       full_name: "",
       html_url: null,
@@ -91,10 +92,35 @@ export default {
     }
     this.clearRepository();
   },
-  mounted() {
+  async mounted() {
+    await this.checkAuth();
     this.recommend();
   },
   methods: {
+    async checkAuth() {
+      const cached = localStorage.getItem("gitrec_auth_state");
+      if (cached) {
+        const { is_authenticated, timestamp } = JSON.parse(cached);
+        if (Date.now() - timestamp < 5 * 60 * 1000) {
+          this.isAuthenticated = is_authenticated;
+          return;
+        }
+      }
+      
+      try {
+        const response = await axios.get("/api/me", { withCredentials: true });
+        this.isAuthenticated = response.data.is_authenticated;
+        if (this.isAuthenticated) {
+          localStorage.setItem("gitrec_auth_state", JSON.stringify({
+            is_authenticated: true,
+            login: response.data.login,
+            timestamp: Date.now()
+          }));
+        }
+      } catch (error) {
+        this.isAuthenticated = false;
+      }
+    },
     recommend() {
       let topic = this.topic;
       if (topic == "/cpp") {
@@ -128,6 +154,10 @@ export default {
       this.like_pressed = false;
     },
     like() {
+      if (!this.isAuthenticated) {
+        this.$router.push("/login");
+        return;
+      }
       axios
         .post("/api/like/" + this.item_id, { withCredentials: true })
         .then(() => {

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -6,7 +6,11 @@
       type="info"
       variant="tonal"
       class="login-alert"
+      role="button"
+      tabindex="0"
       @click="goToLogin"
+      @keydown.enter="goToLogin"
+      @keydown.space.prevent="goToLogin"
     >
       <div class="login-alert__text">
         Login with GitHub to get personalized recommendations based on your starred repositories
@@ -117,10 +121,14 @@ export default {
     async checkAuth() {
       const cached = localStorage.getItem("gitrec_auth_state");
       if (cached) {
-        const { is_authenticated, timestamp } = JSON.parse(cached);
-        if (Date.now() - timestamp < 5 * 60 * 1000) {
-          this.isAuthenticated = is_authenticated;
-          return;
+        try {
+          const { is_authenticated, timestamp } = JSON.parse(cached);
+          if (Date.now() - timestamp < 5 * 60 * 1000) {
+            this.isAuthenticated = is_authenticated;
+            return;
+          }
+        } catch (error) {
+          localStorage.removeItem("gitrec_auth_state");
         }
       }
       
@@ -133,9 +141,12 @@ export default {
             login: response.data.login,
             timestamp: Date.now()
           }));
+        } else {
+          localStorage.removeItem("gitrec_auth_state");
         }
       } catch (error) {
         this.isAuthenticated = false;
+        localStorage.removeItem("gitrec_auth_state");
       }
     },
     recommend() {

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -1,5 +1,22 @@
 <template>
   <div>
+    <!-- Login prompt for anonymous users -->
+    <v-banner 
+      v-if="!isAuthenticated && !hideLoginPrompt"
+      color="info"
+      lines="one"
+      class="login-banner"
+    >
+      <v-banner-text>
+        <v-icon start>mdi-information</v-icon>
+        Login with GitHub to get personalized recommendations based on your starred repositories
+      </v-banner-text>
+      <template #actions>
+        <v-btn color="primary" to="/login" variant="text">Login</v-btn>
+        <v-btn variant="text" @click="hideLoginPrompt = true">Dismiss</v-btn>
+      </template>
+    </v-banner>
+
     <v-container>
       <div v-if="full_name" class="repo-header">
         <a :href="html_url" target="_blank" class="repo-link">
@@ -58,6 +75,7 @@ export default {
     return {
       like_pressed: false,
       isAuthenticated: false,
+      hideLoginPrompt: false,
       item_id: null,
       full_name: "",
       html_url: null,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 asciidoc3==3.2.3
 beautifulsoup4==4.9.3
 celery==5.2.7
-docutils==0.17.1
+docutils==0.22.4
 emoji==1.6.1
 Flask==3.1.3
 flask-cors==4.0.2
@@ -11,7 +11,7 @@ Flask-SQLAlchemy>=3.0.0
 gevent==26.4.0
 gunicorn==23.0.0
 language-detector>=5.0.2
-mistune==2.0.4
+mistune==3.2.0
 mysqlclient>=2.1.0
 openai~=1.77.0
 pickledb==1.3.2


### PR DESCRIPTION
- Remove @login_required decorator from get_repo
- Logged-in users: continue using Gorse recommendation system
- Anonymous users: randomly select a repo from GitHub Trending
- Use global_github_client for anonymous users (no user token required)
- Cache trending data for performance (1 hour expiry)