### PR TITLE
fix: refresh session on auth check to prevent premature expiration

### DIFF
--- a/app.py
+++ b/app.py
@@ -277,6 +277,7 @@ def page_not_found(e):
 @app.route("/api/me")
 def get_me():
     if current_user.is_authenticated:
+        session.permanent = True  # Refresh session on auth check
         return Response(
             json.dumps({"is_authenticated": True, "login": current_user.login}),
             mimetype="application/json"


### PR DESCRIPTION
## Problem

After #166 moved auth check to frontend for CDN-friendly caching, the `session.permanent = True` was removed from the index route. This caused sessions to expire based on default timeout without being refreshed.

Users reported that login state expires very quickly, requiring frequent re-authentication.

## Solution

Add `session.permanent = True` to the `/api/me` endpoint. This ensures the session is refreshed each time the frontend checks authentication status, matching the previous behavior where session was refreshed on every page load.

## Changes

- Added `session.permanent = True` in `/api/me` when user is authenticated