### PR TITLE
Add pnpm config to allow all builds before install

### DIFF
--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -5,6 +5,7 @@ FROM node:24
 RUN corepack enable && corepack prepare pnpm@latest --activate
 COPY frontend frontend
 WORKDIR /frontend
+RUN pnpm config set dangerouslyAllowAllBuilds true
 RUN pnpm install && pnpm build
 
 #################################


### PR DESCRIPTION
Add  before  ERR_PNPM_NO_PKG_MANIFEST  No package.json found in /home/openclaw/clawd/gitrec to avoid build script approval prompts in CI.